### PR TITLE
New tool to reindex a directory of ROS Bag Files

### DIFF
--- a/ros_bag_reindexer.sh
+++ b/ros_bag_reindexer.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Reindexes all bags files in a directory tree, renaming the newly
+# reindexed files so they end in .bag rather than .bag.archive
+#
+# Usage:
+#    ros_bag_reindexer.sh DIRECTORY
+#
+# Val Schmidt
+# Center for Coastal and Ocean Mapping
+# University of New Hampshire
+# 2023
+
+# Get a recursive list of all files in the directory tree that 
+# need reindexing (e.g. ending in active)
+FILES=`find "${1}" -type f | grep '.bag.active'`
+
+# Loop through them, reindexing each, and 
+# renaming them, removing the '.active' 
+# Note, rosbag reindex will create a copy of the original
+# in xxxxx.bag.orig.active. This is retained.
+
+for f in $FILES; do
+  rosbag reindex $f
+  b=`basename $f`
+  d=`dirname $f`
+  outfile="$d/${b%%.*}.bag"
+  mv $f ${outfile}
+done;


### PR DESCRIPTION
Our robots create a lot of orphaned bag files that must be reindexed. This tool will search for them recursively in a directory tree, reindex them, and then rename the result to the original rosbag filename (ending with .bag) so other tools can easy find the indexed version.